### PR TITLE
Fix UTType initializer for DocumentPicker

### DIFF
--- a/FilePickerView.swift
+++ b/FilePickerView.swift
@@ -5,7 +5,7 @@ struct FilePickerView: UIViewControllerRepresentable {
     var onPicked: (URL) -> Void
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
-        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.plainText, UTType.filenameExtension("md")!], asCopy: false)
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.plainText, UTType(filenameExtension: "md")!], asCopy: false)
         controller.allowsMultipleSelection = false
         controller.delegate = context.coordinator
         return controller


### PR DESCRIPTION
## Summary
- fix type initializer in the DocumentPicker setup

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_68405799efe083238d39e598fcf0404a