### PR TITLE
Fix file picker cancel and security access

### DIFF
--- a/DocumentManager.swift
+++ b/DocumentManager.swift
@@ -4,6 +4,12 @@ class DocumentManager: ObservableObject {
     @Published var document: EditableDocument?
 
     func openDocument(at url: URL) {
+        let shouldStopAccessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if shouldStopAccessing {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
         do {
             let content = try String(contentsOf: url, encoding: .utf8)
             self.document = EditableDocument(url: url, content: content)

--- a/FilePickerView.swift
+++ b/FilePickerView.swift
@@ -29,5 +29,9 @@ struct FilePickerView: UIViewControllerRepresentable {
                 onPicked(url)
             }
         }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+            controller.dismiss(animated: true)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- dismiss `UIDocumentPickerViewController` when the user cancels
- start and stop security scoped access when opening files

## Testing
- `swift build --disable-sandbox` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_684072c766108323b4bfb628ddf79c10